### PR TITLE
debian: Simplify rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -11,19 +11,3 @@
 
 %:
 	dh $@
-
-override_dh_auto_clean:
-	rm -rf debian/build
-
-override_dh_auto_configure:
-	mkdir -p debian/build
-	cd debian/build && meson --prefix=/usr ../..
-
-override_dh_auto_build:
-	cd debian/build && ninja -v
-
-override_dh_auto_test:
-	cd debian/build && ninja test
-
-override_dh_auto_install:
-	cd debian/build && DESTDIR=${CURDIR}/debian/com.github.SubhadeepJasu.pebbles ninja install


### PR DESCRIPTION
Debhelper should be able to automatically detect meson, so there is no need to manually tell it how to build the project.