### PR TITLE
Missing translations + Various minor improvements

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -3,6 +3,10 @@ src/MainWindow.vala
 src/ControlsScheme.vala
 src/PreferencesOverlay.vala
 
+src/Views/Displays/CalculusDisplay.vala
+src/Views/Displays/ProgrammerDisplay.vala
+src/Views/Displays/ScientificDisplay.vala
+
 src/Views/MiniCalculator.vala
 src/Views/CalculusView.vala
 src/Views/ScientificView.vala

--- a/po/com.github.subhadeepjasu.pebbles.pot
+++ b/po/com.github.subhadeepjasu.pebbles.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.subhadeepjasu.pebbles\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-05 17:04+0100\n"
+"POT-Creation-Date: 2021-11-05 18:58+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,6 +33,10 @@ msgstr ""
 msgid "All Categories"
 msgstr ""
 
+#: src/MainWindow.vala:179 src/MainWindow.vala:284
+msgid "Pebbles Menu"
+msgstr ""
+
 #: src/MainWindow.vala:187 src/MainWindow.vala:932 src/MainWindow.vala:933
 #: src/MainWindow.vala:934 src/MainWindow.vala:946 src/MainWindow.vala:947
 #: src/MainWindow.vala:948 src/Views/CalculusView.vala:449
@@ -51,6 +55,22 @@ msgstr ""
 #: src/Views/CalculusView.vala:444 src/Views/ScientificView.vala:312
 #: src/Views/ProgrammerView.vala:268
 msgid "Shift"
+msgstr ""
+
+#: src/MainWindow.vala:216 src/Views/DateView.vala:132
+msgid "AGE"
+msgstr ""
+
+#: src/MainWindow.vala:217 src/Views/DateView.vala:133
+msgid "DUR"
+msgstr ""
+
+#: src/MainWindow.vala:227 src/Views/DateView.vala:186
+msgid "ADD"
+msgstr ""
+
+#: src/MainWindow.vala:228 src/Views/DateView.vala:187
+msgid "SUB"
 msgstr ""
 
 #: src/MainWindow.vala:243 src/MainWindow.vala:960 src/MainWindow.vala:961
@@ -80,11 +100,11 @@ msgstr ""
 msgid "Show Controls"
 msgstr ""
 
-#: src/MainWindow.vala:290 src/PreferencesOverlay.vala:120
+#: src/MainWindow.vala:290 src/PreferencesOverlay.vala:127
 msgid "Preferences"
 msgstr ""
 
-#: src/MainWindow.vala:292 src/Views/HistoryView.vala:67
+#: src/MainWindow.vala:292 src/Views/HistoryView.vala:68
 msgid "History"
 msgstr ""
 
@@ -93,17 +113,17 @@ msgid "Show Calculation History"
 msgstr ""
 
 #: src/MainWindow.vala:357 src/Views/ControlsOverlay.vala:45
-#: src/Views/HistoryView.vala:147
+#: src/Views/HistoryView.vala:148
 msgid "Scientific"
 msgstr ""
 
 #: src/MainWindow.vala:358 src/Views/ControlsOverlay.vala:72
-#: src/Views/HistoryView.vala:171
+#: src/Views/HistoryView.vala:172
 msgid "Calculus"
 msgstr ""
 
 #: src/MainWindow.vala:359 src/Views/ControlsOverlay.vala:85
-#: src/Views/HistoryView.vala:176
+#: src/Views/HistoryView.vala:177
 msgid "Programmer"
 msgstr ""
 
@@ -228,7 +248,8 @@ msgstr ""
 
 #: src/ControlsScheme.vala:57 src/Views/MiniCalculator.vala:75
 #: src/Views/CalculusView.vala:177 src/Views/ScientificView.vala:171
-#: src/Views/StatisticsView.vala:136 src/Views/CommonNumericKeypad.vala:55
+#: src/Views/ProgrammerView.vala:137 src/Views/StatisticsView.vala:136
+#: src/Views/CommonNumericKeypad.vala:55
 msgid "All Clear"
 msgstr ""
 
@@ -300,7 +321,7 @@ msgstr ""
 #: src/ControlsScheme.vala:110 src/ControlsScheme.vala:127
 #: src/Views/MiniCalculator.vala:96 src/Views/ScientificView.vala:309
 #: src/Views/ScientificView.vala:355 src/Views/ProgrammerView.vala:265
-#: src/Views/ProgrammerView.vala:352 src/Views/HistoryView.vala:91
+#: src/Views/ProgrammerView.vala:352 src/Views/HistoryView.vala:92
 msgid "Result"
 msgstr ""
 
@@ -356,7 +377,7 @@ msgstr ""
 msgid "Cardinality"
 msgstr ""
 
-#: src/ControlsScheme.vala:159 src/Views/HistoryView.vala:90
+#: src/ControlsScheme.vala:159 src/Views/HistoryView.vala:91
 msgid "Mode"
 msgstr ""
 
@@ -440,78 +461,99 @@ msgstr ""
 msgid "Scientific constants button:"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:59
+#. TRANSLATORS: The left quotation mark symbol
+#: src/PreferencesOverlay.vala:61
+msgid "“"
+msgstr ""
+
+#. TRANSLATORS: The right quotation mark symbol
+#: src/PreferencesOverlay.vala:63
+msgid "”"
+msgstr ""
+
+#: src/PreferencesOverlay.vala:65
 msgid "Constant 1"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:62 src/PreferencesOverlay.vala:76
+#: src/PreferencesOverlay.vala:68 src/PreferencesOverlay.vala:82
 #: src/Views/CalculusView.vala:556 src/Views/CalculusView.vala:598
 #: src/Views/ScientificView.vala:481 src/Views/ScientificView.vala:523
 msgid "Euler's constant (exponential)"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:63 src/PreferencesOverlay.vala:77
+#: src/PreferencesOverlay.vala:69 src/PreferencesOverlay.vala:83
 #: src/Views/CalculusView.vala:520 src/Views/CalculusView.vala:562
 #: src/Views/ScientificView.vala:445 src/Views/ScientificView.vala:487
 msgid "Archimedes' constant (pi)"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:64 src/PreferencesOverlay.vala:78
+#: src/PreferencesOverlay.vala:70 src/PreferencesOverlay.vala:84
 msgid "Parabolic constant"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:65 src/PreferencesOverlay.vala:79
+#: src/PreferencesOverlay.vala:71 src/PreferencesOverlay.vala:85
 #: src/Views/CalculusView.vala:528 src/Views/CalculusView.vala:570
 #: src/Views/ScientificView.vala:453 src/Views/ScientificView.vala:495
 msgid "Golden ratio (phi)"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:66 src/PreferencesOverlay.vala:80
+#: src/PreferencesOverlay.vala:72 src/PreferencesOverlay.vala:86
 #: src/Views/CalculusView.vala:532 src/Views/CalculusView.vala:574
 #: src/Views/ScientificView.vala:457 src/Views/ScientificView.vala:499
 msgid "Euler–Mascheroni constant (gamma)"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:67 src/PreferencesOverlay.vala:81
+#: src/PreferencesOverlay.vala:73 src/PreferencesOverlay.vala:87
 #: src/Views/CalculusView.vala:536 src/Views/CalculusView.vala:578
 #: src/Views/ScientificView.vala:461 src/Views/ScientificView.vala:503
 msgid "Conway's constant (lambda)"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:68 src/PreferencesOverlay.vala:82
+#: src/PreferencesOverlay.vala:74 src/PreferencesOverlay.vala:88
 #: src/Views/CalculusView.vala:540 src/Views/CalculusView.vala:582
 #: src/Views/ScientificView.vala:465 src/Views/ScientificView.vala:507
 msgid "Khinchin's constant"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:69 src/PreferencesOverlay.vala:83
+#: src/PreferencesOverlay.vala:75 src/PreferencesOverlay.vala:89
 #: src/Views/CalculusView.vala:544 src/Views/CalculusView.vala:586
 #: src/Views/ScientificView.vala:469 src/Views/ScientificView.vala:511
 msgid "The Feigenbaum constant alpha"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:70 src/PreferencesOverlay.vala:84
+#: src/PreferencesOverlay.vala:76 src/PreferencesOverlay.vala:90
 #: src/Views/CalculusView.vala:548 src/Views/CalculusView.vala:590
 #: src/Views/ScientificView.vala:473 src/Views/ScientificView.vala:515
 msgid "The Feigenbaum constant delta"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:71 src/PreferencesOverlay.vala:85
+#: src/PreferencesOverlay.vala:77 src/PreferencesOverlay.vala:91
 #: src/Views/CalculusView.vala:552 src/Views/CalculusView.vala:594
 #: src/Views/ScientificView.vala:477 src/Views/ScientificView.vala:519
 msgid "Apery's constant"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:73
+#: src/PreferencesOverlay.vala:79
 msgid "Constant 2 (Hold Shift)"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:102
+#: src/PreferencesOverlay.vala:108
 msgid "Currency Converter API Key"
 msgstr ""
 
-#: src/PreferencesOverlay.vala:105
+#: src/PreferencesOverlay.vala:111
 msgid "Get your own API key"
+msgstr ""
+
+#: src/PreferencesOverlay.vala:114 src/Views/StatisticsView.vala:144
+#: src/Views/BottomPopper.vala:40
+msgid "Reset"
+msgstr ""
+
+#: src/Views/Displays/CalculusDisplay.vala:67
+#: src/Views/Displays/ProgrammerDisplay.vala:106
+#: src/Views/Displays/ScientificDisplay.vala:65
+msgid "SHIFT"
 msgstr ""
 
 #: src/Views/MiniCalculator.vala:88 src/Views/CalculusView.vala:221
@@ -773,14 +815,6 @@ msgstr ""
 msgid "Infer Date"
 msgstr ""
 
-#: src/Views/DateView.vala:132
-msgid "AGE"
-msgstr ""
-
-#: src/Views/DateView.vala:133
-msgid "DUR"
-msgstr ""
-
 #: src/Views/DateView.vala:135
 msgid "From"
 msgstr ""
@@ -795,14 +829,6 @@ msgstr ""
 
 #: src/Views/DateView.vala:154 src/Views/DateView.vala:366
 msgid "Hey, it's the same date"
-msgstr ""
-
-#: src/Views/DateView.vala:186
-msgid "ADD"
-msgstr ""
-
-#: src/Views/DateView.vala:187
-msgid "SUB"
 msgstr ""
 
 #: src/Views/DateView.vala:189
@@ -909,10 +935,6 @@ msgstr ""
 
 #: src/Views/DateView.vala:426
 msgid "Sunday"
-msgstr ""
-
-#: src/Views/StatisticsView.vala:144 src/Views/BottomPopper.vala:40
-msgid "Reset"
 msgstr ""
 
 #: src/Views/StatisticsView.vala:144
@@ -1187,15 +1209,15 @@ msgstr ""
 msgid "Century"
 msgstr ""
 
-#: src/Views/ConvAngleView.vala:47 src/Views/HistoryView.vala:101
+#: src/Views/ConvAngleView.vala:47 src/Views/HistoryView.vala:102
 msgid "Degree"
 msgstr ""
 
-#: src/Views/ConvAngleView.vala:48 src/Views/HistoryView.vala:104
+#: src/Views/ConvAngleView.vala:48 src/Views/HistoryView.vala:105
 msgid "Radian"
 msgstr ""
 
-#: src/Views/ConvAngleView.vala:49 src/Views/HistoryView.vala:107
+#: src/Views/ConvAngleView.vala:49 src/Views/HistoryView.vala:108
 msgid "Gradian"
 msgstr ""
 
@@ -1503,6 +1525,14 @@ msgstr ""
 msgid "South African Rand"
 msgstr ""
 
+#: src/Views/ConvCurrView.vala:176
+msgid "Failed to update forex data!"
+msgstr ""
+
+#: src/Views/ConvCurrView.vala:178
+msgid "Updating foreign exchange data"
+msgstr ""
+
 #: src/Views/ControlsOverlay.vala:33
 msgid "Common"
 msgstr ""
@@ -1519,19 +1549,23 @@ msgstr ""
 msgid "Double click to recall, Right click to insert"
 msgstr ""
 
-#: src/Views/HistoryView.vala:88
-msgid "Input Expression"
+#: src/Views/HistoryView.vala:62
+msgid "Clear history"
 msgstr ""
 
 #: src/Views/HistoryView.vala:89
+msgid "Input Expression"
+msgstr ""
+
+#: src/Views/HistoryView.vala:90
 msgid "Type"
 msgstr ""
 
-#: src/Views/HistoryView.vala:117
+#: src/Views/HistoryView.vala:118
 msgid "Integral"
 msgstr ""
 
-#: src/Views/HistoryView.vala:120
+#: src/Views/HistoryView.vala:121
 msgid "Derivative"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.subhadeepjasu.pebbles\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-05 17:04+0100\n"
-"PO-Revision-Date: 2021-11-05 16:45+0100\n"
+"POT-Creation-Date: 2021-11-05 18:58+0100\n"
+"PO-Revision-Date: 2021-11-05 18:46+0100\n"
 "Last-Translator: Nathan Bonnemains (@NathanBnm)\n"
 "Language-Team: none\n"
 "Language: fr\n"
@@ -33,6 +33,10 @@ msgstr "Activer le mode test"
 msgid "All Categories"
 msgstr "Toutes les catégories"
 
+#: src/MainWindow.vala:179 src/MainWindow.vala:284
+msgid "Pebbles Menu"
+msgstr "Menu de Pebbles"
+
 #: src/MainWindow.vala:187 src/MainWindow.vala:932 src/MainWindow.vala:933
 #: src/MainWindow.vala:934 src/MainWindow.vala:946 src/MainWindow.vala:947
 #: src/MainWindow.vala:948 src/Views/CalculusView.vala:449
@@ -52,6 +56,22 @@ msgstr "Radians"
 #: src/Views/ProgrammerView.vala:268
 msgid "Shift"
 msgstr "Maj"
+
+#: src/MainWindow.vala:216 src/Views/DateView.vala:132
+msgid "AGE"
+msgstr "ÂGE"
+
+#: src/MainWindow.vala:217 src/Views/DateView.vala:133
+msgid "DUR"
+msgstr "DURÉE"
+
+#: src/MainWindow.vala:227 src/Views/DateView.vala:186
+msgid "ADD"
+msgstr "ADDITIONNER"
+
+#: src/MainWindow.vala:228 src/Views/DateView.vala:187
+msgid "SUB"
+msgstr "SOUSTRAIRE"
 
 #: src/MainWindow.vala:243 src/MainWindow.vala:960 src/MainWindow.vala:961
 #: src/MainWindow.vala:978 src/Views/ProgrammerView.vala:347
@@ -80,11 +100,11 @@ msgstr "Dernière mise à jour le "
 msgid "Show Controls"
 msgstr "Afficher les contrôles"
 
-#: src/MainWindow.vala:290 src/PreferencesOverlay.vala:120
+#: src/MainWindow.vala:290 src/PreferencesOverlay.vala:127
 msgid "Preferences"
 msgstr "Préférences"
 
-#: src/MainWindow.vala:292 src/Views/HistoryView.vala:67
+#: src/MainWindow.vala:292 src/Views/HistoryView.vala:68
 msgid "History"
 msgstr "Historique"
 
@@ -93,17 +113,17 @@ msgid "Show Calculation History"
 msgstr "Afficher l'historique des calculs"
 
 #: src/MainWindow.vala:357 src/Views/ControlsOverlay.vala:45
-#: src/Views/HistoryView.vala:147
+#: src/Views/HistoryView.vala:148
 msgid "Scientific"
 msgstr "Scientifique"
 
 #: src/MainWindow.vala:358 src/Views/ControlsOverlay.vala:72
-#: src/Views/HistoryView.vala:171
+#: src/Views/HistoryView.vala:172
 msgid "Calculus"
 msgstr "Calcul"
 
 #: src/MainWindow.vala:359 src/Views/ControlsOverlay.vala:85
-#: src/Views/HistoryView.vala:176
+#: src/Views/HistoryView.vala:177
 msgid "Programmer"
 msgstr "Programmeur"
 
@@ -228,7 +248,8 @@ msgstr "Fermer"
 
 #: src/ControlsScheme.vala:57 src/Views/MiniCalculator.vala:75
 #: src/Views/CalculusView.vala:177 src/Views/ScientificView.vala:171
-#: src/Views/StatisticsView.vala:136 src/Views/CommonNumericKeypad.vala:55
+#: src/Views/ProgrammerView.vala:137 src/Views/StatisticsView.vala:136
+#: src/Views/CommonNumericKeypad.vala:55
 msgid "All Clear"
 msgstr "Tout effacer"
 
@@ -300,7 +321,7 @@ msgstr "Constantes"
 #: src/ControlsScheme.vala:110 src/ControlsScheme.vala:127
 #: src/Views/MiniCalculator.vala:96 src/Views/ScientificView.vala:309
 #: src/Views/ScientificView.vala:355 src/Views/ProgrammerView.vala:265
-#: src/Views/ProgrammerView.vala:352 src/Views/HistoryView.vala:91
+#: src/Views/ProgrammerView.vala:352 src/Views/HistoryView.vala:92
 msgid "Result"
 msgstr "Résultat"
 
@@ -356,7 +377,7 @@ msgstr "Supprimer toutes les cellules (Réinitialiser)"
 msgid "Cardinality"
 msgstr "Cardinalité"
 
-#: src/ControlsScheme.vala:159 src/Views/HistoryView.vala:90
+#: src/ControlsScheme.vala:159 src/Views/HistoryView.vala:91
 msgid "Mode"
 msgstr "Mode"
 
@@ -440,79 +461,100 @@ msgstr "Précise"
 msgid "Scientific constants button:"
 msgstr "Bouton de constante scientifique"
 
-#: src/PreferencesOverlay.vala:59
+#. TRANSLATORS: The left quotation mark symbol
+#: src/PreferencesOverlay.vala:61
+msgid "“"
+msgstr "« "
+
+#. TRANSLATORS: The right quotation mark symbol
+#: src/PreferencesOverlay.vala:63
+msgid "”"
+msgstr " »"
+
+#: src/PreferencesOverlay.vala:65
 msgid "Constant 1"
 msgstr "Constante 1"
 
-#: src/PreferencesOverlay.vala:62 src/PreferencesOverlay.vala:76
+#: src/PreferencesOverlay.vala:68 src/PreferencesOverlay.vala:82
 #: src/Views/CalculusView.vala:556 src/Views/CalculusView.vala:598
 #: src/Views/ScientificView.vala:481 src/Views/ScientificView.vala:523
 msgid "Euler's constant (exponential)"
 msgstr "Constante d'Euler (exponentielle)"
 
-#: src/PreferencesOverlay.vala:63 src/PreferencesOverlay.vala:77
+#: src/PreferencesOverlay.vala:69 src/PreferencesOverlay.vala:83
 #: src/Views/CalculusView.vala:520 src/Views/CalculusView.vala:562
 #: src/Views/ScientificView.vala:445 src/Views/ScientificView.vala:487
 msgid "Archimedes' constant (pi)"
 msgstr "Constante d'Archimède (pi)"
 
-#: src/PreferencesOverlay.vala:64 src/PreferencesOverlay.vala:78
+#: src/PreferencesOverlay.vala:70 src/PreferencesOverlay.vala:84
 msgid "Parabolic constant"
 msgstr "Constante parabolique"
 
-#: src/PreferencesOverlay.vala:65 src/PreferencesOverlay.vala:79
+#: src/PreferencesOverlay.vala:71 src/PreferencesOverlay.vala:85
 #: src/Views/CalculusView.vala:528 src/Views/CalculusView.vala:570
 #: src/Views/ScientificView.vala:453 src/Views/ScientificView.vala:495
 msgid "Golden ratio (phi)"
 msgstr "Nombre d'or (phi)"
 
-#: src/PreferencesOverlay.vala:66 src/PreferencesOverlay.vala:80
+#: src/PreferencesOverlay.vala:72 src/PreferencesOverlay.vala:86
 #: src/Views/CalculusView.vala:532 src/Views/CalculusView.vala:574
 #: src/Views/ScientificView.vala:457 src/Views/ScientificView.vala:499
 msgid "Euler–Mascheroni constant (gamma)"
 msgstr "Constante d'Euler–Mascheroni (gamma)"
 
-#: src/PreferencesOverlay.vala:67 src/PreferencesOverlay.vala:81
+#: src/PreferencesOverlay.vala:73 src/PreferencesOverlay.vala:87
 #: src/Views/CalculusView.vala:536 src/Views/CalculusView.vala:578
 #: src/Views/ScientificView.vala:461 src/Views/ScientificView.vala:503
 msgid "Conway's constant (lambda)"
 msgstr "Constante de Conway (lambda)"
 
-#: src/PreferencesOverlay.vala:68 src/PreferencesOverlay.vala:82
+#: src/PreferencesOverlay.vala:74 src/PreferencesOverlay.vala:88
 #: src/Views/CalculusView.vala:540 src/Views/CalculusView.vala:582
 #: src/Views/ScientificView.vala:465 src/Views/ScientificView.vala:507
 msgid "Khinchin's constant"
 msgstr "Constante de Khintchine"
 
-#: src/PreferencesOverlay.vala:69 src/PreferencesOverlay.vala:83
+#: src/PreferencesOverlay.vala:75 src/PreferencesOverlay.vala:89
 #: src/Views/CalculusView.vala:544 src/Views/CalculusView.vala:586
 #: src/Views/ScientificView.vala:469 src/Views/ScientificView.vala:511
 msgid "The Feigenbaum constant alpha"
 msgstr "Constante alpha de Feigenbaum"
 
-#: src/PreferencesOverlay.vala:70 src/PreferencesOverlay.vala:84
+#: src/PreferencesOverlay.vala:76 src/PreferencesOverlay.vala:90
 #: src/Views/CalculusView.vala:548 src/Views/CalculusView.vala:590
 #: src/Views/ScientificView.vala:473 src/Views/ScientificView.vala:515
 msgid "The Feigenbaum constant delta"
 msgstr "Constante delta de Feigenbaum"
 
-#: src/PreferencesOverlay.vala:71 src/PreferencesOverlay.vala:85
+#: src/PreferencesOverlay.vala:77 src/PreferencesOverlay.vala:91
 #: src/Views/CalculusView.vala:552 src/Views/CalculusView.vala:594
 #: src/Views/ScientificView.vala:477 src/Views/ScientificView.vala:519
 msgid "Apery's constant"
 msgstr "Constante d'Apéry"
 
-#: src/PreferencesOverlay.vala:73
+#: src/PreferencesOverlay.vala:79
 msgid "Constant 2 (Hold Shift)"
 msgstr "Constante 2 (Maintenir Maj)"
 
-#: src/PreferencesOverlay.vala:102
+#: src/PreferencesOverlay.vala:108
 msgid "Currency Converter API Key"
 msgstr "Clé d'API du convertisseur de devises"
 
-#: src/PreferencesOverlay.vala:105
+#: src/PreferencesOverlay.vala:111
 msgid "Get your own API key"
 msgstr "Obtenir votre clé d'API"
+
+#: src/PreferencesOverlay.vala:114 src/Views/StatisticsView.vala:144
+#: src/Views/BottomPopper.vala:40
+msgid "Reset"
+msgstr "Réinitialiser"
+
+#: src/Views/Displays/CalculusDisplay.vala:67
+#: src/Views/Displays/ProgrammerDisplay.vala:106
+#: src/Views/Displays/ScientificDisplay.vala:65
+msgid "SHIFT"
+msgstr "MAJ"
 
 #: src/Views/MiniCalculator.vala:88 src/Views/CalculusView.vala:221
 #: src/Views/ScientificView.vala:215 src/Views/DateView.vala:94
@@ -777,15 +819,7 @@ msgstr "Calculer la différence"
 
 #: src/Views/DateView.vala:125
 msgid "Infer Date"
-msgstr "Date antérieure"
-
-#: src/Views/DateView.vala:132
-msgid "AGE"
-msgstr "AGE"
-
-#: src/Views/DateView.vala:133
-msgid "DUR"
-msgstr "DUR"
+msgstr "Calcul de date"
 
 #: src/Views/DateView.vala:135
 msgid "From"
@@ -802,14 +836,6 @@ msgstr "Différence"
 #: src/Views/DateView.vala:154 src/Views/DateView.vala:366
 msgid "Hey, it's the same date"
 msgstr "C'est la même date"
-
-#: src/Views/DateView.vala:186
-msgid "ADD"
-msgstr "AJOUTER"
-
-#: src/Views/DateView.vala:187
-msgid "SUB"
-msgstr "SOUSTRAIRE"
 
 #: src/Views/DateView.vala:189
 msgid "Starting from"
@@ -916,10 +942,6 @@ msgstr "Samedi"
 #: src/Views/DateView.vala:426
 msgid "Sunday"
 msgstr "Dimanche"
-
-#: src/Views/StatisticsView.vala:144 src/Views/BottomPopper.vala:40
-msgid "Reset"
-msgstr "Réinitialiser"
 
 #: src/Views/StatisticsView.vala:144
 msgid "Clear sample"
@@ -1193,15 +1215,15 @@ msgstr "Décennie"
 msgid "Century"
 msgstr "Siècle"
 
-#: src/Views/ConvAngleView.vala:47 src/Views/HistoryView.vala:101
+#: src/Views/ConvAngleView.vala:47 src/Views/HistoryView.vala:102
 msgid "Degree"
 msgstr "Degré"
 
-#: src/Views/ConvAngleView.vala:48 src/Views/HistoryView.vala:104
+#: src/Views/ConvAngleView.vala:48 src/Views/HistoryView.vala:105
 msgid "Radian"
 msgstr "Radian"
 
-#: src/Views/ConvAngleView.vala:49 src/Views/HistoryView.vala:107
+#: src/Views/ConvAngleView.vala:49 src/Views/HistoryView.vala:108
 msgid "Gradian"
 msgstr "Gradian"
 
@@ -1509,6 +1531,14 @@ msgstr "Rouble russe"
 msgid "South African Rand"
 msgstr "Rand sud-africain"
 
+#: src/Views/ConvCurrView.vala:176
+msgid "Failed to update forex data!"
+msgstr "Échec de la mise à jour des données Forex !"
+
+#: src/Views/ConvCurrView.vala:178
+msgid "Updating foreign exchange data"
+msgstr "Mise à jour des données de change"
+
 #: src/Views/ControlsOverlay.vala:33
 msgid "Common"
 msgstr "Commun"
@@ -1525,19 +1555,23 @@ msgstr "Contrôles de Pebbles"
 msgid "Double click to recall, Right click to insert"
 msgstr "Double clic pour rappel, clic droit pour insérer"
 
-#: src/Views/HistoryView.vala:88
+#: src/Views/HistoryView.vala:62
+msgid "Clear history"
+msgstr "Effacer l'historique"
+
+#: src/Views/HistoryView.vala:89
 msgid "Input Expression"
 msgstr "Expression saisie"
 
-#: src/Views/HistoryView.vala:89
+#: src/Views/HistoryView.vala:90
 msgid "Type"
 msgstr "Type"
 
-#: src/Views/HistoryView.vala:117
+#: src/Views/HistoryView.vala:118
 msgid "Integral"
 msgstr "Intégrale"
 
-#: src/Views/HistoryView.vala:120
+#: src/Views/HistoryView.vala:121
 msgid "Derivative"
 msgstr "Dérivée"
 

--- a/po/meson.build
+++ b/po/meson.build
@@ -2,7 +2,8 @@
 i18n.gettext (meson.project_name (),
   args: [
     '--directory=' + meson.source_root (),
-    '--from-code=UTF-8'
+    '--from-code=UTF-8',
+    '-cTRANSLATORS'
   ]
 )
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -176,7 +176,7 @@ namespace Pebbles {
             leaflet_back_button = new StyledButton (_("All Categories"));
             leaflet_back_button.valign = Gtk.Align.CENTER;
             leaflet_back_button.set_image (new Gtk.Image.from_icon_name ("view-more-symbolic", Gtk.IconSize.SMALL_TOOLBAR));
-            leaflet_back_button.tooltip_text = "Pebbles Menu";
+            leaflet_back_button.tooltip_text = _("Pebbles Menu");
             leaflet_back_button.clicked.connect (() => {
                 if (main_leaflet.get_visible_child () == common_view)
                     main_leaflet.set_visible_child (item_list);
@@ -213,8 +213,8 @@ namespace Pebbles {
 
             // Make Date Switcher ///////////////////////////////////////
             date_mode_stack = new Gtk.Stack ();
-            date_age_label = new Gtk.Label ("AGE");
-            date_dur_label = new Gtk.Label ("DUR");
+            date_age_label = new Gtk.Label (_("AGE"));
+            date_dur_label = new Gtk.Label (_("DUR"));
             diff_mode_switch = new Gtk.Switch ();
             diff_mode_switch.get_style_context ().add_class ("mode-switch");
             date_diff_grid = new Gtk.Grid ();
@@ -224,8 +224,8 @@ namespace Pebbles {
             date_diff_grid.attach (date_dur_label, 2, 0, 1, 1);
             date_diff_grid.valign = Gtk.Align.CENTER;
 
-            date_add_label = new Gtk.Label ("ADD");
-            date_sub_label = new Gtk.Label ("SUB");
+            date_add_label = new Gtk.Label (_("ADD"));
+            date_sub_label = new Gtk.Label (_("SUB"));
             add_mode_switch = new Gtk.Switch ();
             add_mode_switch.get_style_context ().add_class ("mode-switch");
             date_add_grid = new Gtk.Grid ();
@@ -281,7 +281,7 @@ namespace Pebbles {
             app_menu.set_margin_top (8);
             app_menu.set_margin_bottom (8);
             app_menu.set_image (new Gtk.Image.from_icon_name ("open-menu-symbolic", Gtk.IconSize.SMALL_TOOLBAR));
-            app_menu.tooltip_text = "Pebbles Menu";
+            app_menu.tooltip_text = _("Pebbles Menu");
 
             var settings_menu = new Gtk.Menu ();
             var controls_overlay_item = new Gtk.MenuItem();

--- a/src/PreferencesOverlay.vala
+++ b/src/PreferencesOverlay.vala
@@ -56,33 +56,39 @@ namespace Pebbles {
             var constant_button_label = new Gtk.Label (_("Scientific constants button:"));
             constant_button_label.get_style_context ().add_class ("h4");
             constant_button_label.halign = Gtk.Align.START;
+
+            // TRANSLATORS: The left quotation mark symbol
+            var laquo = _("“");
+            // TRANSLATORS: The right quotation mark symbol
+            var raquo = _("”");
+
             var constant_label1 = new Gtk.Label (_("Constant 1"));
             constant_label1.halign = Gtk.Align.START;
             constants_select_1 = new Gtk.ComboBoxText ();
-            constants_select_1.append_text (_("Euler's constant (exponential)") + "  \"e\"");
-            constants_select_1.append_text (_("Archimedes' constant (pi)") + "  \"\xCF\x80\"");
-            constants_select_1.append_text (_("Parabolic constant") + "  \"\xF0\x9D\x91\x83\"");
-            constants_select_1.append_text (_("Golden ratio (phi)") + "  \"\xCF\x86\"");
-            constants_select_1.append_text (_("Euler–Mascheroni constant (gamma)") + "  \"\xF0\x9D\x9B\xBE\"");
-            constants_select_1.append_text (_("Conway's constant (lambda)") + "  \"\xCE\xBB\"");
-            constants_select_1.append_text (_("Khinchin's constant") + "  \"K\"");
-            constants_select_1.append_text (_("The Feigenbaum constant alpha") + "  \"\xCE\xB1\"");
-            constants_select_1.append_text (_("The Feigenbaum constant delta") + "  \"\xCE\xB4\"");
-            constants_select_1.append_text (_("Apery's constant") + "  \"\xF0\x9D\x9B\x87(3)\"");
+            constants_select_1.append_text (_("Euler's constant (exponential)") + "  " + laquo + "e" + raquo);
+            constants_select_1.append_text (_("Archimedes' constant (pi)") + "  " + laquo + "\xCF\x80" + raquo);
+            constants_select_1.append_text (_("Parabolic constant") + "  " + laquo + "\xF0\x9D\x91\x83" + raquo);
+            constants_select_1.append_text (_("Golden ratio (phi)") + "  " + laquo + "\xCF\x86" + raquo);
+            constants_select_1.append_text (_("Euler–Mascheroni constant (gamma)") + "  " + laquo + "\xF0\x9D\x9B\xBE" + raquo);
+            constants_select_1.append_text (_("Conway's constant (lambda)") + "  " + laquo + "\xCE\xBB" + raquo);
+            constants_select_1.append_text (_("Khinchin's constant") + "  " + laquo + "K" + raquo);
+            constants_select_1.append_text (_("The Feigenbaum constant alpha") + "  " + laquo + "\xCE\xB1" + raquo);
+            constants_select_1.append_text (_("The Feigenbaum constant delta") + "  " + laquo + "\xCE\xB4" + raquo);
+            constants_select_1.append_text (_("Apery's constant") + "  " + laquo + "\xF0\x9D\x9B\x87(3)" + raquo);
 
             var constant_label2 = new Gtk.Label (_("Constant 2 (Hold Shift)"));
             constant_label2.halign = Gtk.Align.START;
             constants_select_2 = new Gtk.ComboBoxText ();
-            constants_select_2.append_text (_("Euler's constant (exponential)") + "  \"e\"");
-            constants_select_2.append_text (_("Archimedes' constant (pi)") + "  \"\xCF\x80\"");
-            constants_select_2.append_text (_("Parabolic constant") + "  \"\xF0\x9D\x91\x83\"");
-            constants_select_2.append_text (_("Golden ratio (phi)") + "  \"\xCF\x86\"");
-            constants_select_2.append_text (_("Euler–Mascheroni constant (gamma)") + "  \"\xF0\x9D\x9B\xBE\"");
-            constants_select_2.append_text (_("Conway's constant (lambda)") + "  \"\xCE\xBB\"");
-            constants_select_2.append_text (_("Khinchin's constant") + "  \"K\"");
-            constants_select_2.append_text (_("The Feigenbaum constant alpha") + "  \"\xCE\xB1\"");
-            constants_select_2.append_text (_("The Feigenbaum constant delta") + "  \"\xCE\xB4\"");
-            constants_select_2.append_text (_("Apery's constant") + "  \"\xF0\x9D\x9B\x87(3)\"");
+            constants_select_2.append_text (_("Euler's constant (exponential)") + "  " + laquo + "e" + raquo);
+            constants_select_2.append_text (_("Archimedes' constant (pi)") + "  " + laquo + "\xCF\x80" + raquo);
+            constants_select_2.append_text (_("Parabolic constant") + "  " + laquo + "\xF0\x9D\x91\x83" + raquo);
+            constants_select_2.append_text (_("Golden ratio (phi)") + "  " + laquo + "\xCF\x86" + raquo);
+            constants_select_2.append_text (_("Euler–Mascheroni constant (gamma)") + "  " + laquo + "\xF0\x9D\x9B\xBE" + raquo);
+            constants_select_2.append_text (_("Conway's constant (lambda)") + "  " + laquo + "\xCE\xBB" + raquo);
+            constants_select_2.append_text (_("Khinchin's constant") + "  " + laquo + "K" + raquo);
+            constants_select_2.append_text (_("The Feigenbaum constant alpha") + "  " + laquo + "\xCE\xB1" + raquo);
+            constants_select_2.append_text (_("The Feigenbaum constant delta") + "  " + laquo + "\xCE\xB4" + raquo);
+            constants_select_2.append_text (_("Apery's constant") + "  " + laquo + "\xF0\x9D\x9B\x87(3)" + raquo);
 
             this.delete_event.connect (() => {
                 save_settings ();
@@ -105,6 +111,7 @@ namespace Pebbles {
             forex_api_link = new Gtk.LinkButton.with_label ("https://free.currencyconverterapi.com/", _("Get your own API key"));
             forex_api_key = new Gtk.Entry ();
             forex_api_key.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY,"edit-undo-symbolic");
+            forex_api_key.set_icon_tooltip_markup (Gtk.EntryIconPosition.SECONDARY, _("Reset"));
             forex_api_key.placeholder_text = "03eb97e97cbf3fa3e228";
             
             main_grid.attach (forex_label, 0, 9, 1, 1);

--- a/src/Views/ConvCurrView.vala
+++ b/src/Views/ConvCurrView.vala
@@ -173,9 +173,9 @@ namespace Pebbles {
             
             add (main_grid);
             
-            toast = new Granite.Widgets.Toast ("Failed to update forex data!");
+            toast = new Granite.Widgets.Toast (_("Failed to update forex data!"));
             waiting_overlay_bar = new Granite.Widgets.OverlayBar (this);
-            waiting_overlay_bar.label = "Updating foreign exchange data";
+            waiting_overlay_bar.label = _("Updating foreign exchange data");
             waiting_overlay_bar.active = true;
             waiting_overlay_bar.opacity = 0.0;
             

--- a/src/Views/Displays/CalculusDisplay.vala
+++ b/src/Views/Displays/CalculusDisplay.vala
@@ -64,7 +64,7 @@ namespace Pebbles {
             memory_label.get_style_context ().add_class ("pebbles_h4");
             memory_label.hexpand = true;
             memory_label.set_opacity (0.2);
-            shift_label    = new Gtk.Label ("SHIFT");
+            shift_label    = new Gtk.Label (_("SHIFT"));
             shift_label.get_style_context ().add_class ("pebbles_h4");
             shift_label.set_opacity (0.2);
             shift_label.set_halign (Gtk.Align.END);

--- a/src/Views/Displays/ProgrammerDisplay.vala
+++ b/src/Views/Displays/ProgrammerDisplay.vala
@@ -103,7 +103,7 @@ namespace Pebbles {
             memory_label.get_style_context ().add_class ("pebbles_h4");
             memory_label.set_opacity (0.2);
             memory_label.hexpand = true;
-            shift_label    = new Gtk.Label ("SHIFT");
+            shift_label    = new Gtk.Label (_("SHIFT"));
             shift_label.get_style_context ().add_class ("pebbles_h4");
             shift_label.set_opacity (0.2);
             

--- a/src/Views/Displays/ScientificDisplay.vala
+++ b/src/Views/Displays/ScientificDisplay.vala
@@ -62,7 +62,7 @@ namespace Pebbles {
             memory_label.hexpand = true;
             memory_label.get_style_context ().add_class ("pebbles_h4");
             memory_label.set_opacity (0.2);
-            shift_label    = new Gtk.Label ("SHIFT");
+            shift_label    = new Gtk.Label (_("SHIFT"));
             shift_label.get_style_context ().add_class ("pebbles_h4");
             shift_label.set_opacity (0.2);
             shift_label.set_halign (Gtk.Align.END);

--- a/src/Views/HistoryView.vala
+++ b/src/Views/HistoryView.vala
@@ -59,6 +59,7 @@ namespace Pebbles {
             scrolled_window.height_request = 400;
 
             clear_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            clear_button.tooltip_text = _("Clear history");
 
             var headerbar = new Gtk.HeaderBar ();
             headerbar.has_subtitle = false;

--- a/src/Views/ProgrammerView.vala
+++ b/src/Views/ProgrammerView.vala
@@ -134,7 +134,7 @@ namespace Pebbles {
             button_container_right.vexpand = true;
 
             // Make buttons on the left
-            all_clear_button = new StyledButton ("AC", "All Clear", {"Delete"});
+            all_clear_button = new StyledButton ("AC", _("All Clear"), {"Delete"});
             all_clear_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
             all_clear_button.get_style_context ().add_class ("pebbles_button_font_size");
             del_button = new Gtk.Button.from_icon_name ("edit-clear-symbolic", Gtk.IconSize.BUTTON);


### PR DESCRIPTION
Just noticed that in some places translation was missing.

I made some minor changes regarding textual content too.

Changelog:

- Allow "SHIFT" translation in displays for Scientific, Calculus and Programmer modes
- Make left and right quotation marks translatable for constant lists (differs between languages)
- Allow comments for translators using `// TRANSLATORS:`
- Add "Clear history" tooltip text to history view delete icon button
- Add "Reset" tooltip text to API key field undo icon in preferences overlay